### PR TITLE
Fix replit virtualenv issues

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,5 +1,6 @@
 language = "python3"
-run = "python3 index.py -use-device-auth -use-authorization-code"
+run = "source $(poetry env info --path)/bin/activate && python3 index.py -use-device-auth -use-authorization-code"
+compile = "poetry install"
 
 [nix]
 channel = "stable-22_11"


### PR DESCRIPTION
This should make replit install & run everything just by running the repl.

To make replit work properly the repo must be cloned with a `Blank` template!!